### PR TITLE
add barcode-scanning dep (mlkit)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,7 +32,7 @@ android {
 }
 
 dependencies {
-
+    implementation("com.google.mlkit:barcode-scanning:17.2.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.10.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")


### PR DESCRIPTION
Adds a barcode scanning dependency from Google's mlkit.

Would be useful in scanning barcodes.

Relates to resolving #20.