### PR TITLE
add text recognition dep (mlkit)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,7 +32,7 @@ android {
 }
 
 dependencies {
-
+    implementation("com.google.mlkit:text-recognition:16.0.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.10.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")


### PR DESCRIPTION
Adds a text recognition dependency from Google's mlkit.

Would be useful in scanning serial codes.

Currently only the Latin preset is used, however if needed, Hanzi, Kanji & Kana, Hangeul and Devanagari are also supported.

Relates to resolving #19.